### PR TITLE
🔧 Ignores `Tests` folder for coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "Tests/**/*"


### PR DESCRIPTION
CodeCov is analyzing coverage of tests files… which I'm not interested in :/
This should ignore the tests folder and only take coverage for the framework