### PR TITLE
✅ Tests for invalid model in array

### DIFF
--- a/MammutAPI.xcodeproj/project.pbxproj
+++ b/MammutAPI.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		CCF53D0FE7AFBDE01600F1C1 /* Mention.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF53B781C595EF54CCBA246 /* Mention.swift */; };
 		CCF53E75EA866A3629E6A508 /* Attachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF53552E6D8D06FA42881B9 /* Attachment.swift */; };
 		CCF53E849B74D422A1BA268F /* AccountMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF53B4BE62D3B0330F59E44 /* AccountMapper.swift */; };
+		CCF53EA974BD8860ED91950B /* StatusWithInvalidAttachments.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF533F3FDBA56ED8DF16AA6 /* StatusWithInvalidAttachments.json */; };
 		CCF53EF210F571773E170A18 /* IncompleteJSON.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF53EB6959D0311677F12FB /* IncompleteJSON.json */; };
 		CCF53F704FDF234D48809C38 /* Attachment.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF53CF4F61AF421BD6C1D4D /* Attachment.json */; };
 		CCF53F778F9FEBB166E2C143 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF53D6D7A500B9EFDF80E5E /* Account.swift */; };
@@ -95,6 +96,7 @@
 		CCF532523107CE309D544695 /* MammutAPITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MammutAPITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCF53252BCF40A0E94A93D40 /* StatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusTests.swift; sourceTree = "<group>"; };
 		CCF533C630254DBF6165A4A7 /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
+		CCF533F3FDBA56ED8DF16AA6 /* StatusWithInvalidAttachments.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = StatusWithInvalidAttachments.json; sourceTree = "<group>"; };
 		CCF5346211BD6A976E70D0DA /* Date+Mastodon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Mastodon.swift"; sourceTree = "<group>"; };
 		CCF5346D5994CCA8036DADF2 /* StatusVisibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusVisibility.swift; sourceTree = "<group>"; };
 		CCF5347B21B4535E62B6370A /* MentionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MentionTests.swift; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 				CCF53684D1FDFBA97DF929A8 /* StatusWithAttachments.json */,
 				CCF53FEAE8D9648E432644F4 /* Mention.json */,
 				CCF534E4E8D2DAC244A77031 /* StatusWithMentions.json */,
+				CCF533F3FDBA56ED8DF16AA6 /* StatusWithInvalidAttachments.json */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -459,6 +462,7 @@
 				CCF538E0561995C2B35666EA /* StatusWithAttachments.json in Resources */,
 				CCF5381230A683C62728D744 /* Mention.json in Resources */,
 				CCF5333096F2160A55434789 /* StatusWithMentions.json in Resources */,
+				CCF53EA974BD8860ED91950B /* StatusWithInvalidAttachments.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/MammutAPI/Mappers/ModelMapping.swift
+++ b/Sources/MammutAPI/Mappers/ModelMapping.swift
@@ -70,5 +70,4 @@ extension ModelMapping {
         }
         return mappedResult
     }
-
 }

--- a/Tests/MammutAPITests/Internal/Fixtures/StatusWithInvalidAttachments.json
+++ b/Tests/MammutAPITests/Internal/Fixtures/StatusWithInvalidAttachments.json
@@ -1,0 +1,63 @@
+{
+  "account": {
+    "acct": "testAccount@test.instance",
+    "avatar": "https://brandchecker.com/assets/img/websites/mastodon.png",
+    "avatar_static": "https://brandchecker.com/assets/img/websites/mastodon.png",
+    "created_at": "2017-04-06T06:15:34.583Z",
+    "display_name": "Test Account",
+    "followers_count": 3,
+    "following_count": 0,
+    "header": "https://thumbs.mic.com/Yzg4Njc2ZWMzNCMveVFQdVBVOGZrTjdhRmFuRDRycDc1UUtRcmpJPS8zOXgxOjEyMjl4NjIxLzgwMHg0NTAvZmlsdGVyczpmb3JtYXQoanBlZyk6cXVhbGl0eSg4MCkvaHR0cHM6Ly9zMy5hbWF6b25hd3MuY29tL3BvbGljeW1pYy1pbWFnZXMvaGUyMjRlZzMzZWh1aXg3d2VpendlZ3R3M2VoMWJnMXBlaThvY2tiM2N6d292YWlhb2JsMHlyeTZvbGczYzlleS5qcGc.jpg",
+    "header_static": "https://thumbs.mic.com/Yzg4Njc2ZWMzNCMveVFQdVBVOGZrTjdhRmFuRDRycDc1UUtRcmpJPS8zOXgxOjEyMjl4NjIxLzgwMHg0NTAvZmlsdGVyczpmb3JtYXQoanBlZyk6cXVhbGl0eSg4MCkvaHR0cHM6Ly9zMy5hbWF6b25hd3MuY29tL3BvbGljeW1pYy1pbWFnZXMvaGUyMjRlZzMzZWh1aXg3d2VpendlZ3R3M2VoMWJnMXBlaThvY2tiM2N6d292YWlhb2JsMHlyeTZvbGczYzlleS5qcGc.jpg",
+    "id": 0,
+    "locked": false,
+    "note": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+    "statuses_count": 148,
+    "url": "https://test.instance/@testAccount",
+    "username": "testAccount"
+  },
+  "application": null,
+  "content": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>",
+  "created_at": "2017-04-16T20:20:57.000Z",
+  "favourited": null,
+  "favourites_count": 0,
+  "id": 0,
+  "in_reply_to_account_id": null,
+  "in_reply_to_id": null,
+  "media_attachments": [
+    {
+      "id": 20300,
+      "remote_url": "https://test.instance/file.png",
+      "type": "image",
+      "url": "https://test.instance/file",
+      "preview_url": "https://test.instance/file.png?1492486953",
+      "text_url": "https://test.instance/textURL"
+    },
+    {
+      "id": 20302,
+      "remote_url": "https://test.instance/file.png",
+      "type": "image",
+      "url": "https://test.instance/file",
+      "preview_url": "https://test.instance/file.png?1492486953",
+      "text_url": "https://test.instance/textURL"
+    },
+    {
+      "id": null,
+      "remote_url": null,
+      "type": "image",
+      "url": "https://test.instance/file",
+      "preview_url": "https://test.instance/file.png?1492486953",
+      "text_url": "https://test.instance/textURL"
+    }
+  ],
+  "mentions": [],
+  "reblog": null,
+  "reblogged": null,
+  "reblogs_count": 0,
+  "sensitive": false,
+  "spoiler_text": "",
+  "tags": [],
+  "uri": "tag:test.instance,2017-04-16:objectId=2852827:objectType=Status",
+  "url": "https://test.instance/users/testAccount/updates/0",
+  "visibility": "public"
+}

--- a/Tests/MammutAPITests/Mappers/StatusMapperTests.swift
+++ b/Tests/MammutAPITests/Mappers/StatusMapperTests.swift
@@ -133,6 +133,15 @@ internal class StatusMapperTests: XCTestCase {
         XCTAssertEqual(status.mediaAttachments.count, 0)
     }
 
+    func test_map_jsonWith1InvalidAnd2ValidAttachments_setsAttachmentsToArrayOf2() throws {
+        let fileName = "StatusWithInvalidAttachments.json"
+        let json = try Fixture.loadJSON(from: fileName)
+        let result = subject.map(json: json)
+        let status: Status = try AssertNotNilAndUnwrap(result.value)
+        XCTAssertNil(result.error)
+        XCTAssertEqual(status.mediaAttachments.count, 2)
+    }
+
     func test_map_jsonWithMentions_setsMentionsToValidMentionObjects() throws {
         let fileName = "StatusWithMentions.json"
         let json = try Fixture.loadJSON(from: fileName)
@@ -169,6 +178,7 @@ extension StatusMapperTests {
                 ("test_map_jsonWithApplication_setsApplicationToValidApplicationObject", test_map_jsonWithApplication_setsApplicationToValidApplicationObject),
                 ("test_map_jsonWithAttachments_setsAttachmentsToValidAttachmentsObjects", test_map_jsonWithAttachments_setsAttachmentsToValidAttachmentsObjects),
                 ("test_map_jsonWithoutAttachments_setsAttachmentsToEmptyArray", test_map_jsonWithoutAttachments_setsAttachmentsToEmptyArray),
+                ("test_map_jsonWith1InvalidAnd2ValidAttachments_setsAttachmentsToArrayOf2", test_map_jsonWith1InvalidAnd2ValidAttachments_setsAttachmentsToArrayOf2),
                 ("test_map_jsonWithMentions_setsMentionsToValidMentionObjects", test_map_jsonWithMentions_setsMentionsToValidMentionObjects),
                 ("test_map_jsonWithoutMentions_setsMentionsToEmptyArray", test_map_jsonWithoutMentions_setsMentionsToEmptyArray)
         ]


### PR DESCRIPTION
Wasn't testing just «assuming» behaviour. So I added some tests to better check this behaviour.
Since its shared on all mappers due to the protocol extension is fine with just testing it once.